### PR TITLE
Log Failed Videos

### DIFF
--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -15,6 +15,7 @@ from .config import (
     REQUESTS_CA_BUNDLE,
     USE_POTENTIAL_DUPES_QUEUE,
     ONLY_SEND_QUEUED_DUPES,
+    PARALLEL_JOB_COUNT,
 )
 from .dedup import HydrusVideoDeduplicator
 from .pdq import PotentialDuplicatesQueue
@@ -52,7 +53,16 @@ def main(
     clear_search_cache: Annotated[
         Optional[bool], typer.Option(help="Clear the cache that tracks what files have already been compared")
     ] = False,
-    job_count: Annotated[Optional[int], typer.Option(help="Number of CPUs to use. Default is all but one core.")] = -2,
+    job_count: Annotated[Optional[int], typer.Option(help="Number of CPUs to use. Default is all but one core.")] = int(
+        PARALLEL_JOB_COUNT
+    ),
+    failed_videos_page: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Name of page to add any failed files to. Page MUST already be created in your Hydrus client before "
+            "running."
+        ),
+    ] = None,
     verbose: Annotated[Optional[bool], typer.Option(help="Verbose logging")] = False,
     debug: Annotated[Optional[bool], typer.Option(hidden=True)] = False,
 ):
@@ -104,6 +114,7 @@ def main(
             hydrus_client,
             file_service_keys=file_service_key,
             job_count=job_count,
+            failed_videos_page=failed_videos_page,
         )
     except hydrus_api.InsufficientAccess as exc:
         error_connecting_exception_msg = "Invalid Hydrus API key."

--- a/src/hydrusvideodeduplicator/config.py
+++ b/src/hydrusvideodeduplicator/config.py
@@ -50,6 +50,8 @@ if in_wsl():
 
 HYDRUS_API_URL = os.getenv("HYDRUS_API_URL", f"https://{_DEFAULT_IP}:{_DEFAULT_PORT}")
 
+PARALLEL_JOB_COUNT = os.getenv("PARALLEL_JOB_COUNT", -2)
+
 # ~/.local/share/hydrusvideodeduplicator/ on Linux
 _DEDUP_DATABASE_DIR_ENV = PlatformDirs("hydrusvideodeduplicator").user_data_dir
 _DEDUP_DATABASE_DIR_ENV = os.getenv("DEDUP_DATABASE_DIR", _DEDUP_DATABASE_DIR_ENV)
@@ -63,6 +65,9 @@ REQUESTS_CA_BUNDLE = os.getenv("REQUESTS_CA_BUNDLE")
 _PDQ_DATABASE_NAME = os.getenv("DEDUP_DATABASE_NAME", "pdq")
 PDQ_DATABASE_FILE = Path(DEDUP_DATABASE_DIR, f"{_PDQ_DATABASE_NAME}.sqlite")
 PDQ_TABLE_NAME = "potential_duplicates_queue"
+
+_FAILED_VIDEOS_LOG_FILE_NAME = os.getenv("FAILED_VIDEOS_LOG_FILE_NAME", "failed_videos_log.txt")
+FAILED_VIDEOS_LOG_FILE = Path(DEDUP_DATABASE_DIR, _FAILED_VIDEOS_LOG_FILE_NAME)
 
 USE_POTENTIAL_DUPES_QUEUE = True if os.getenv("USE_POTENTIAL_DUPES_QUEUE") else False
 PDQ_FLUSH_COUNT = os.getenv("PDQ_FLUSH_COUNT", 16)

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -22,6 +22,7 @@ import hydrusvideodeduplicator.hydrus_api.utils as hydrus_api_utils
 from .config import DEDUP_DATABASE_DIR, DEDUP_DATABASE_FILE
 from .dedup_util import database_accessible, get_potential_duplicate_count_hydrus
 from .pdq import PotentialDuplicatesQueue, Relationship
+from .fvl import FailedVideoLogger
 from .vpdqpy.vpdqpy import Vpdq
 
 
@@ -38,11 +39,14 @@ class HydrusVideoDeduplicator:
         verify_connection: bool = True,
         file_service_keys: Sequence[str] | None = None,
         job_count: int = -2,
+        failed_videos_page: str | None = None,
     ):
         self.client = client
         if verify_connection:
             self.verify_api_connection()
         self.job_count = job_count
+
+        self.failed_files = FailedVideoLogger(client, self.hydlog, failed_videos_page)
 
         # Commonly used things from the Hydrus database
         # If any of these are large they should probably be lazily loaded
@@ -140,14 +144,17 @@ class HydrusVideoDeduplicator:
         )["hashes"]
         return all_video_hashes
 
-    def fetch_and_hash_file(self, video_hash: str) -> tuple | None:
+    def fetch_and_hash_file(self, video_hash: str) -> tuple:
         """Retrieves the video from Hydrus and calculates its perceptual hash"""
+
+        PHashedVideo = namedtuple("PHashedVideo", "video_hash perceptual_hash success exception")
+
         try:
             video_response = self.client.get_file(hash_=video_hash)
-        except hydrus_api.HydrusAPIException:
+        except hydrus_api.HydrusAPIException as exc:
             print("[red] Failed to get video from Hydrus.")
-            self.hydlog.error("Error getting video from Hydrus.")
-            return None
+            self.hydlog.error(f"Error getting video hash {video_hash} from Hydrus.")
+            return PHashedVideo(video_hash, None, False, exc)
 
         # Calculate perceptual_hash
         try:
@@ -156,10 +163,9 @@ class HydrusVideoDeduplicator:
             print("[red] Failed to calculate a perceptual hash.")
             self.hydlog.exception(exc)
             self.hydlog.error(f"Errored file hash: {video_hash}")
-            return None
+            return PHashedVideo(video_hash, None, False, exc)
         else:
-            PHashedVideo = namedtuple("PHashedVideo", "video_hash perceptual_hash")
-            return PHashedVideo(video_hash, perceptual_hash)
+            return PHashedVideo(video_hash, perceptual_hash, True, None)
 
     def add_perceptual_hashes_to_db(self, overwrite: bool, video_hashes: Sequence[str]) -> None:
         """
@@ -206,20 +212,22 @@ class HydrusVideoDeduplicator:
 
                 with tqdm(total=len(new_video_hashes), dynamic_ncols=True, unit="video", colour="BLUE") as pbar:
                     # Change to return_as='unordered_generator' when joblib supports it! (should be soon)
+                    # For status check https://github.com/joblib/joblib/issues/1449
                     with Parallel(n_jobs=self.job_count, return_as='generator') as parallel:
                         result_generator = parallel(
                             delayed(self.fetch_and_hash_file)(video_hash) for video_hash in new_video_hashes
                         )
                         for result in result_generator:
-                            if result is None:
-                                continue
-                            video_hash = result.video_hash
-                            perceptual_hash = result.perceptual_hash
-                            row = hashdb.get(video_hash, {})
-                            row["perceptual_hash"] = perceptual_hash
-                            hashdb[video_hash] = row
+                            if result.success is not True:
+                                self.failed_files.log(result.video_hash, result.exception)
+                            else:
+                                video_hash = result.video_hash
+                                perceptual_hash = result.perceptual_hash
+                                row = hashdb.get(video_hash, {})
+                                row["perceptual_hash"] = perceptual_hash
+                                hashdb[video_hash] = row
+                                hash_count += 1
 
-                            hash_count += 1
                             pbar.update(1)
 
             except KeyboardInterrupt:
@@ -230,6 +238,7 @@ class HydrusVideoDeduplicator:
 
             finally:
                 print(f"[green] Added {hash_count} new videos to the database.")
+                self.failed_files.finish()
 
     def compare_videos(self, video1_hash: str, video2_hash: str, video1_phash: str, video2_phash: str) -> None:
         """Compare videos and mark them as potential duplicates in Hydrus if they are similar."""

--- a/src/hydrusvideodeduplicator/fvl.py
+++ b/src/hydrusvideodeduplicator/fvl.py
@@ -1,0 +1,95 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+from logging import Logger
+from datetime import datetime
+from .config import FAILED_VIDEOS_LOG_FILE
+
+import hydrusvideodeduplicator.hydrus_api as hydrus_api
+
+
+class FailedVideoLogger:
+    """Utility object for logging any videos that can't be perceptually hashed for whatever reason. Always logs
+    failed videos (with exception info) to .txt file, and optionally sends failed videos to a specified page in the
+    Hydrus Client."""
+
+    def __init__(self, client: hydrus_api, hydlog: Logger, page_name: str | None):
+        self.client = client
+        self.hydlog = hydlog
+        self.page_name = page_name
+        self.page_key = self._get_page_key() if page_name is not None else None
+        self.failed_video_list = []
+        self._init_log_file()
+
+    def log(self, video_hash: str, exception: Exception) -> None:
+        """Logs provided video hash to .txt log file, and also to Hydrus page if one was provided"""
+        self.failed_video_list.append(video_hash)
+        self._add_to_hydrus_page(video_hash)
+        self._add_to_log_file(video_hash, exception)
+
+    def finish(self) -> None:
+        """Appends the final information to the .txt log file"""
+        with open(FAILED_VIDEOS_LOG_FILE, "a", encoding="utf-8") as log_file:
+            if len(self.failed_video_list) == 0:
+                log_file.write("No videos failed during the phashing process.")
+            else:
+                log_file.write("List of all failed video hashes (can be pasted into Hydrus):\n")
+                for video_hash in self.failed_video_list:
+                    log_file.write(video_hash + "\n")
+
+    def _add_to_hydrus_page(self, video_hash: str) -> None:
+        """Adds provided video to Hydrus Client file page, if a valid file page name was provided via the CLI"""
+        if self.page_key is None:
+            return
+
+        try:
+            self.client.add_files_to_page(page_key=self.page_key, hashes=[video_hash])
+        except Exception as e:
+            self.hydlog.debug(
+                f"Error when trying to add file {video_hash} to client page {self.page_name} (key='{self.page_key}')"
+            )
+            self.hydlog.debug(e)
+
+    @staticmethod
+    def _add_to_log_file(video_hash: str, exception: Exception) -> None:
+        """Adds provided video hash to the .txt log file, along with any information provided by the Exception thrown
+        when the video failed phashing"""
+        with open(FAILED_VIDEOS_LOG_FILE, "a", encoding="utf-8") as log_file:
+            log_file.writelines([f"video hash: {video_hash}\n", "Failed with exception:\n", str(exception) + "\n\n"])
+
+    def _get_page_key(self) -> str | None:
+        """Takes the provided page name, and searches through all the pages in the Hydrus client for an appropriate
+        page with that name. If there are multiple pages with the same name, one of those pages is chosen
+        pseudo-randomly."""
+        response = self.client.get_pages()
+        page_key = self._find_page_key_from_name(response["pages"])
+
+        if page_key is None:
+            self.hydlog.info(
+                f"Warning: could not find file search page for name matching '{self.page_name}'. "
+                f"Failed files will not be sent to Hydrus client page"
+            )
+
+        return page_key
+
+    def _find_page_key_from_name(self, page: dict[str, any]) -> str | None:
+        """Recursive function to search the response JSON provided by the Hydrus API's get_pages call. Because every
+        page can potentially contain other pages, a recursive search through the object is necessary. As soon as a
+        page is found with the correct page name and page type, that page's page_key is returned."""
+        if page["name"].lower() == self.page_name.lower() and page["page_type"] == 6:
+            return page["page_key"]
+        elif "pages" in page:
+            for subpage in page["pages"]:
+                result = self._find_page_key_from_name(subpage)
+                if result is not None:
+                    return result
+        return None
+
+    @staticmethod
+    def _init_log_file() -> None:
+        """Initializes the .txt log file, overwriting any leftover contents from prior runs"""
+        with open(FAILED_VIDEOS_LOG_FILE, "w", encoding="utf-8") as log_file:
+            log_file.write("===== Log of Videos That Failed PHashing Process =====\n")
+            log_file.write(f"Runtime start: {datetime.now()}\n\n")


### PR DESCRIPTION
This commit implements the following:
- The feature request from issue #15 is functional. The new CLI argument to specify the page name is --failed-videos-page.
- Additionally, all phashing failures with video-specific information are now simultaneously logged to a .txt file for easier info collection (file stored in the same directory as the database files)
- The --job-count parameter can now be set via environment variable
- An additional comment has been added with a specific link for checking the status of 'unordered-generator' on joblib's GH